### PR TITLE
Indent global.mak and autodetect COMPILER

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ git:
   depth: 1
 env:
   global:
-    - MAKEFLAGS="-j 20"
+    - MAKEFLAGS="-j 2"
 
 before_script:
   
@@ -34,7 +34,7 @@ script:
   - cd src
   - rm -r -f ../bin/linux/
   - make clean
-  - COMPILER=gcc6 CXX=g++-6 FC=gfortran-6 STATIC=no make -j 20 install
+  - COMPILER=gcc6 CXX=g++-6 FC=gfortran-6 STATIC=no make -j 2 install
   - cd ..
   - #wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - #bash miniconda.sh -b -p $HOME/miniconda

--- a/src/global.mak
+++ b/src/global.mak
@@ -13,15 +13,15 @@
 
 # Autodetect SYSTEM
 ifeq ($(OS),Windows_NT)
-SYSTEM ?= win
+    SYSTEM ?= win
 else
-UNAME_S := $(shell uname -s)
-ifeq ($(UNAME_S),Linux)
-SYSTEM ?= linux
-endif
-ifeq ($(UNAME_S),Darwin)
-SYSTEM ?= mac
-endif
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S),Linux)
+        SYSTEM ?= linux
+    endif
+    ifeq ($(UNAME_S),Darwin)
+        SYSTEM ?= mac
+    endif
 endif
 
 # Defaults (if unset, or missing local.mak)
@@ -30,140 +30,138 @@ COMPILER ?= intel
 
 
 ifeq ($(SYSTEM),mac)
-# macOS
-bindir ?= $(top_builddir)/../bin/mac/
+    # macOS
+    bindir ?= $(top_builddir)/../bin/mac/
 else ifeq ($(SYSTEM),linux)
-# GNU Linux
-bindir ?= $(top_builddir)/../bin/linux/
-MKLROOT ?= /opt/intel/compilers_and_libraries/linux/mkl
-
+    # GNU Linux
+    bindir ?= $(top_builddir)/../bin/linux/
 else ifeq ($(SYSTEM),win)
-# Microsoft Windows
-bindir ?= $(top_builddir)/../bin/windows/
+    # Microsoft Windows
+    bindir ?= $(top_builddir)/../bin/windows/
 else
-$(error SYSTEM not understood: $(SYSTEM). Use one of mac, linux or win.)
+    $(error SYSTEM not understood: $(SYSTEM). Use one of mac, linux or win.)
 endif
 
 # Determine static (default '-static') or shared dynamic linking
 STATIC ?= -static
 ifndef STATIC
-STATIC = no
+    STATIC = no
 endif
 
 ifeq ($(SYSTEM),win)
-# Microsoft Windows
-EXE_EXT = .exe
-OBJ_EXT = .obj
-LIB_EXT = .lib
-CP = copy
-RM = del /Q
-MKDIR = md
+    # Microsoft Windows
+    EXE_EXT = .exe
+    OBJ_EXT = .obj
+    LIB_EXT = .lib
+    CP = copy
+    RM = del /Q
+    MKDIR = md
 else
-# POSIX (mac, linux)
-OBJ_EXT = .o
-LIB_PRE = lib
-LIB_EXT = .a
-CP = cp
-MKDIR = mkdir -p
+    # POSIX (mac, linux)
+    OBJ_EXT = .o
+    LIB_PRE = lib
+    LIB_EXT = .a
+    CP = cp
+    MKDIR = mkdir -p
 endif
 
 ifeq ($(COMPILER),intel)
-# Intel compilers
-ifeq ($(SYSTEM),win)
-# Warning: this build method is not well tested
-CXX = icl
-OPT_FLAGS = /nologo /O2 /Qmkl:sequential
-CXXFLAGS = $(OPT_FLAGS) /Qstd=c++11 /EHsc
-FFLAGS = $(OPT_FLAGS) /fpp
-FFREE   = /free
-else # mac,linux
-CXX = icpc
-OPT_FLAGS = -O2 -mkl=sequential
-CXXFLAGS = $(OPT_FLAGS) -std=c++11
-FFLAGS = $(OPT_FLAGS) -fpp
-FFREE = -free
-endif
-FC = ifort
+    # Intel compilers
+    ifeq ($(SYSTEM),win)
+        # Warning: this build method is not well tested
+        CXX = icl
+        OPT_FLAGS = /nologo /O2 /Qmkl:sequential
+        CXXFLAGS = $(OPT_FLAGS) /Qstd=c++11 /EHsc
+        FFLAGS = $(OPT_FLAGS) /fpp
+        FFREE   = /free
+    else # mac,linux
+        CXX = icpc
+        OPT_FLAGS = -O2 -mkl=sequential
+        CXXFLAGS = $(OPT_FLAGS) -std=c++11
+        FFLAGS = $(OPT_FLAGS) -fpp
+        FFREE = -free
+    endif
+    FC = ifort
 
-ifeq ($(SYSTEM),win)
-EXT_INCLUDES = -I"$(MKLROOT)"\include
-EXT_LIBS = \
-    mkl_blas95_lp64.lib \
-    mkl_lapack95_lp64.lib
-ifeq ($(STATIC),no)  # dynamic linking
-EXT_LIBS += \
-    mkl_intel_lp64_dll.lib \
-    mkl_sequential_dll.lib \
-    mkl_core_dll.lib
-else  # static linking
-EXT_LIBS += \
-    mkl_intel_lp64.lib \
-    mkl_sequential.lib \
-    mkl_core.lib
-endif
-else ifeq ($(SYSTEM),linux)
-EXT_INCLUDES = -I${MKLROOT}/include/intel64/ilp64 -I${MKLROOT}/include
-EXT_LIBS = \
-    ${MKLROOT}/lib/intel64/libmkl_blas95_lp64.a \
-    ${MKLROOT}/lib/intel64/libmkl_lapack95_lp64.a
-ifeq ($(STATIC),no)  # dynamic linking
-EXT_LIBS += \
-    -L${MKLROOT}/lib/intel64 \
-    -lmkl_intel_lp64 -lmkl_sequential -lmkl_core
-else  # static linking
-EXT_LIBS += \
-    -Wl,--start-group \
-        ${MKLROOT}/lib/intel64/libmkl_intel_lp64.a \
-        ${MKLROOT}/lib/intel64/libmkl_sequential.a \
-        ${MKLROOT}/lib/intel64/libmkl_core.a \
-    -Wl,--end-group \
-    -lifport
-endif
-EXT_LIBS += -lifcore -lpthread -lm -ldl
-else ifeq ($(SYSTEM),mac)
-MKLROOT ?= /opt/intel/compilers_and_libraries_2018.1.126/mac/mkl
-EXTRADIR = /opt/intel/compilers_and_libraries_2018.1.126/mac/compiler
-EXT_INCLUDES = -I${MKLROOT}/include/intel64/lp64 -I${MKLROOT}/include
-EXT_LIBS = \
-    ${MKLROOT}/lib/libmkl_lapack95_ilp64.a \
-    ${MKLROOT}/lib/libmkl_blas95_ilp64.a
-ifeq ($(STATIC),no)  # dynamic linking
-EXT_LIBS += \
-    -L${MKLROOT}/lib \
-    -Wl,-rpath,${MKLROOT}/lib \
-    -lmkl_intel_lp64 -lmkl_sequential -lmkl_core
-else  # static linking
-EXT_LIBS += \
-    ${MKLROOT}/lib/libmkl_intel_ilp64.a \
-    ${MKLROOT}/lib/libmkl_sequential.a \
-    ${MKLROOT}/lib/libmkl_core.a \
-    ${EXTRADIR}/lib/libifcore.a
-endif
-EXT_LIBS += -lpthread -lm -ldl
-endif # $(SYSTEM)
+    ifeq ($(SYSTEM),win)
+        EXT_INCLUDES = -I"$(MKLROOT)"\include
+        EXT_LIBS = \
+            mkl_blas95_lp64.lib \
+            mkl_lapack95_lp64.lib
+        ifeq ($(STATIC),no)  # dynamic linking
+            EXT_LIBS += \
+                mkl_intel_lp64_dll.lib \
+                mkl_sequential_dll.lib \
+                mkl_core_dll.lib
+        else  # static linking
+            EXT_LIBS += \
+                mkl_intel_lp64.lib \
+                mkl_sequential.lib \
+                mkl_core.lib
+        endif
+    else ifeq ($(SYSTEM),linux)
+        EXT_INCLUDES = -I${MKLROOT}/include/intel64/ilp64 -I${MKLROOT}/include
+        EXT_LIBS = \
+            ${MKLROOT}/lib/intel64/libmkl_blas95_lp64.a \
+            ${MKLROOT}/lib/intel64/libmkl_lapack95_lp64.a
+        ifeq ($(STATIC),no)  # dynamic linking
+            EXT_LIBS += \
+                -L${MKLROOT}/lib/intel64 \
+                -lmkl_intel_lp64 -lmkl_sequential -lmkl_core
+        else  # static linking
+            EXT_LIBS += \
+                -Wl,--start-group \
+                    ${MKLROOT}/lib/intel64/libmkl_intel_lp64.a \
+                    ${MKLROOT}/lib/intel64/libmkl_sequential.a \
+                    ${MKLROOT}/lib/intel64/libmkl_core.a \
+                -Wl,--end-group \
+                -lifport
+        endif
+        EXT_LIBS += -lifcore -lpthread -lm -ldl
+    else ifeq ($(SYSTEM),mac)
+        MKLROOT ?= /opt/intel/compilers_and_libraries_2018.1.126/mac/mkl
+        EXTRADIR = /opt/intel/compilers_and_libraries_2018.1.126/mac/compiler
+        EXT_INCLUDES = -I${MKLROOT}/include/intel64/lp64 -I${MKLROOT}/include
+        EXT_LIBS = \
+             ${MKLROOT}/lib/libmkl_lapack95_ilp64.a \
+            ${MKLROOT}/lib/libmkl_blas95_ilp64.a
+        ifeq ($(STATIC),no)  # dynamic linking
+            EXT_LIBS += \
+                -L${MKLROOT}/lib \
+                -Wl,-rpath,${MKLROOT}/lib \
+                -lmkl_intel_lp64 -lmkl_sequential -lmkl_core
+        else  # static linking
+            EXT_LIBS += \
+                ${MKLROOT}/lib/libmkl_intel_ilp64.a \
+                ${MKLROOT}/lib/libmkl_sequential.a \
+                ${MKLROOT}/lib/libmkl_core.a \
+            ${EXTRADIR}/lib/libifcore.a
+        endif
+        EXT_LIBS += -lpthread -lm -ldl
+    endif # $(SYSTEM)
 else  # $(COMPILER)
-# Assume GNU Compiler Collection
-ifeq ($(COMPILER),gcc)
-CXX = g++
-FC = gfortran
-else
-CXX ?= g++
-FC ?= gfortran
-endif
-OPT_FLAGS = -O2
-CXXFLAGS = $(OPT_FLAGS) -std=c++11
-FFLAGS = $(OPT_FLAGS) -cpp
-FFREE = -ffree-form
-EXT_LIBS = -lpthread -llapack -lblas -lgfortran -lquadmath
+    # Assume GNU Compiler Collection
+    ifeq ($(COMPILER),gcc)
+        CXX = g++
+        FC = gfortran
+    else
+        CXX ?= g++
+        FC ?= gfortran
+    endif
+    OPT_FLAGS = -O2
+    CXXFLAGS = $(OPT_FLAGS) -std=c++11
+    FFLAGS = $(OPT_FLAGS) -cpp
+    FFREE = -ffree-form
+    EXT_LIBS = -lpthread -llapack -lblas -lgfortran -lquadmath
 # else
-# $(error COMPILER not understood: $(COMPILER). Use one of intel or gcc.)
+#     $(error COMPILER not understood: $(COMPILER). Use one of intel or gcc.)
 endif  # $(COMPILER)
 
 # Assume linker is the C++ compiler
 LD = $(CXX)
 LDFLAGS += -pthread
 ifneq ($(STATIC),no)
-LDFLAGS += $(STATIC)
+    LDFLAGS += $(STATIC)
 endif
 
 # r=insert with replacement; c=create archive; s=add index


### PR DESCRIPTION
First commit applies 4-space indents for visual appeal and readability. Make doesn't care about whitespace in these contexts.

Second commit does some autodetection for COMPILER. If `ifort` is there, then it is set to intel. Otherwise gnu.

Lastly, Travis CI only has [2 cores](https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system), so [`make -j 2`](https://docs.travis-ci.com/user/speeding-up-the-build/#makefile-parallelization-example) is the limit.